### PR TITLE
Fix/timeout handling

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -27,9 +27,9 @@ void cmd_get_packet() {
   channel = serial_rx_byte();
   timeout_ms = serial_rx_word();
   result = get_packet_and_write_to_serial(channel, timeout_ms);
-  if (result == 0) {
-    // Timed out
-    serial_tx_byte(0);
+  if (result != 0) {
+    serial_rx_byte(result);
+    serial_rx_byte(0);
   }
 }
 
@@ -38,7 +38,7 @@ void cmd_get_state() {
 }
 
 void cmd_get_version() {
-  serial_tx_str("subg_rfspy 0.4");
+  serial_tx_str("subg_rfspy 0.5");
 }
 
 void do_cmd(uint8_t cmd) {
@@ -88,15 +88,15 @@ void cmd_send_and_listen() {
   send_packet_from_serial(send_channel, repeat_count, delay_ms);
   result = get_packet_and_write_to_serial(listen_channel, timeout_ms);
 
-  while (result == 0 && retry_count > 0) {
+  while (result == ERROR_RX_TIMEOUT && retry_count > 0) {
     resend_from_tx_buf(send_channel);
     result = get_packet_and_write_to_serial(listen_channel, timeout_ms);
     retry_count--;
   }
 
-  if (result == 0) {
-    // Timed out, and no retries left
-    serial_tx_byte(ERROR_RX_TIMEOUT);
+  if (result != 0) {
+    // Error, and no retries left
+    serial_tx_byte(result);
     serial_tx_byte(0);
   }
 }

--- a/commands.c
+++ b/commands.c
@@ -28,8 +28,8 @@ void cmd_get_packet() {
   timeout_ms = serial_rx_word();
   result = get_packet_and_write_to_serial(channel, timeout_ms);
   if (result != 0) {
-    serial_rx_byte(result);
-    serial_rx_byte(0);
+    serial_tx_byte(result);
+    serial_tx_byte(0);
   }
 }
 

--- a/commands.h
+++ b/commands.h
@@ -1,8 +1,9 @@
 #ifndef COMMANDS_H
 #define COMMANDS_H
 
-#define ERROR_RX_TIMEOUT 0xbb
-#define ERROR_ZERO_DATA 0xaa
+#define ERROR_RX_TIMEOUT 0xaa
+#define ERROR_CMD_INTERRUPTED 0xbb
+#define ERROR_ZERO_DATA 0xcc
 
 void get_command();
 

--- a/common.mk
+++ b/common.mk
@@ -45,6 +45,6 @@ output:
 	mkdir output
 
 output/${TARGET_BUILD}: output
-	mkdir output/${TARGET_BUILD}/
+	mkdir -p output/${TARGET_BUILD}/
 
 output/${TARGET_BUILD}/%.rel : %.c Makefile

--- a/radio.c
+++ b/radio.c
@@ -241,7 +241,7 @@ uint8_t get_packet_and_write_to_serial(uint8_t channel, uint16_t timeout_ms) {
     }
 
     if (timeout_ms > 0 && timerCounter > timeout_ms && radio_rx_buf_len == 0) {
-      rval = ERROR_TIMEOUT;
+      rval = ERROR_RX_TIMEOUT;
       break;
     }
   
@@ -254,6 +254,7 @@ uint8_t get_packet_and_write_to_serial(uint8_t channel, uint16_t timeout_ms) {
       // We will interrupt the RX and go handle the command.
       interrupting_cmd = serial_rx_byte();
       rval = ERROR_CMD_INTERRUPTED;
+      break;
     }
   }
   RFST = RFST_SIDLE;


### PR DESCRIPTION
This PR makes handling of interruptions and timeouts consistent.  Previously, depending on which command you issued (cmd_get_packet vs cmd_send_and_listen), you would only sometimes get a response packet to the command if you interrupted it or if it timed out.

Now you will always get a response to every command, even if you interrupt a running command. 