### PR TITLE
Added suggestion about running 'export RFSPY_RTSCTS=0'

### DIFF
--- a/tools/serial_rf_spy.py
+++ b/tools/serial_rf_spy.py
@@ -53,14 +53,13 @@ class SerialRfSpy:
       data = self.get_response(1)
       if data == "OK":
         print "RileyLink " + data
-        break 
-      print "retry", len(data), str(data).encode('hex')
- 
+        break
+      print "retry", len(data), str(data).encode('hex'), "(Do you need to run 'export RFSPY_RTSCTS=0' first?)"
+
     while 1:
       self.send_command(self.CMD_GET_VERSION) 
       data = self.get_response(1)
       if len(data) >= 3:
         print "Version: " + data
-        break 
-      print "retry", len(data), str(data).encode('hex')
-
+        break
+      print "retry", len(data), str(data).encode('hex'), "(Do you need to run 'export RFSPY_RTSCTS=0' first?)"


### PR DESCRIPTION
People are quite often caught out not setting this environment variables for the ERF and other devices.

This adds it to the error-case output, since the base message isn't very descriptive.
